### PR TITLE
Fixed stack exchange bug

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
@@ -23,7 +23,7 @@ public class PreviewProviderServiceImpl implements PreviewProviderService {
 
                 // only preview questions, not other stack overflow pages
                 String[] parts = url.getPath().split("/");
-                if (parts.length > 1 && parts[1].equalsIgnoreCase("questions")) {
+                if (parts.length > 1 && parts[1].equalsIgnoreCase("questions") && parts[2].matches("-?\\d+")) {
                     return "stackexchange";
                 }
             } catch (MalformedURLException ignored) {

--- a/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
@@ -23,7 +23,7 @@ public class PreviewProviderServiceImpl implements PreviewProviderService {
 
                 // only preview questions, not other stack overflow pages
                 String[] parts = url.getPath().split("/");
-                if (parts.length > 1 && parts[1].equalsIgnoreCase("questions") && parts[2].matches("-?\\d+")) {
+                if (parts.length > 1 && parts[1].equalsIgnoreCase("questions") && parts[2].matches("\\d+")) {
                     return "stackexchange";
                 }
             } catch (MalformedURLException ignored) {

--- a/src/main/java/edu/ucsb/cs56/mapache_search/search/SearchResult.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/search/SearchResult.java
@@ -79,4 +79,9 @@ public class SearchResult {
         e.kind = "error";
         return e;
     }
+
+    @Override
+    public String toString() {
+        return "SearchResult [items=" + items + ", kind=" + kind + ", searchInformation=" + searchInformation + "]";
+    }
 }


### PR DESCRIPTION
Fixed the bug where certain searches, like "python" or "loop", crashed Mapache Search. The issue: we were assuming any StackExchange link of the form "/questions/..." was a question, and trying to parse the ID from the url. But some links are of the form "/questions/tagged/python", which is actually not a question at all but a category. The fix was to stop treatting links which don't contain a number after the "/questions/" as StackExchange questions