### PR TITLE
pb/ns - created and linked upvote history placeholder page

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/controllers/UpvoteHistoryController.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/controllers/UpvoteHistoryController.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs56.mapache_search.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import edu.ucsb.cs56.mapache_search.entities.AppUser;
+import edu.ucsb.cs56.mapache_search.membership.AuthControllerAdvice;
+import edu.ucsb.cs56.mapache_search.repositories.UserRepository;
+
+
+@Controller
+public class UpvoteHistoryController {
+
+    private Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    @Autowired
+    private AuthControllerAdvice controllerAdvice;
+
+    @GetMapping("/user/upvotehistory")
+    public String upvoteHist (Model model){
+        return "user/upvotehistory";
+    }
+}
+

--- a/src/main/resources/templates/user/settings.html
+++ b/src/main/resources/templates/user/settings.html
@@ -12,10 +12,17 @@
         <p th:text="'Hello, ' + ${user.username} + '!'"></p>
       </div>
       <div class="container">
-        <h3>Instructions for getting API Key</h3>
-        <a href="https://developers.google.com/custom-search/v1/overview"
-          target="_blank" rel="noopener noreferrer">
-          Click Here to get API Key
+        <p>
+          <h3>Instructions for getting API Key</h3>
+          <a href="https://developers.google.com/custom-search/v1/overview" target="_blank" rel="noopener noreferrer">
+            Click Here to get API Key
+          </a>
+        </p>
+        </div>
+      <div class="container">
+        <h3>Upvote History</h3>
+        <a href="upvotehistory">
+          Click Here to get to your upvote history
         </a>
       </div>
       <!-- for debugging

--- a/src/main/resources/templates/user/upvotehistory.html
+++ b/src/main/resources/templates/user/upvotehistory.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+ <html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+  <head>
+ 	<title>Upvote History</title>
+ 	<div th:replace="fragments/bootstrap_head.html"></div>
+ </head>
+
+  <body class="text-center">
+ 	<div class="container">
+ 		<div th:replace="fragments/bootstrap_nav_header.html"></div>
+ 		<h2 class="text-center">Upvote History Page</h2>
+ 		<div th:replace="fragments/bootstrap_footer.html"></div>
+ 	</div>
+ 	<div th:replace="fragments/bootstrap_scripts.html"></div>
+ </body>
+
+  </html> 


### PR DESCRIPTION
link to that page is located in the settings page

Acceptance Criteria: 
- [x] When going to the user settings page, there is a link to the upvote history page 
- [x] Link to the upvote history page brings you to it's placeholder page when clicked
- [x] Can access url from the home page by typing in "/user/upvotehistory"