### PR TITLE
ns/pb - added tag history page and linked to it in settings

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/controllers/TagHistoryController.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/controllers/TagHistoryController.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs56.mapache_search.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import edu.ucsb.cs56.mapache_search.entities.AppUser;
+import edu.ucsb.cs56.mapache_search.membership.AuthControllerAdvice;
+import edu.ucsb.cs56.mapache_search.repositories.UserRepository;
+
+
+@Controller
+public class TagHistoryController {
+
+    private Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    @Autowired
+    private AuthControllerAdvice controllerAdvice;
+
+    @GetMapping("/user/taghistory")
+    public String tagHist (Model model){
+        return "user/taghistory";
+    }
+}
+

--- a/src/main/resources/templates/user/settings.html
+++ b/src/main/resources/templates/user/settings.html
@@ -20,10 +20,20 @@
         </p>
         </div>
       <div class="container">
+        <p>
         <h3>Upvote History</h3>
         <a href="upvotehistory">
           Click Here to get to your upvote history
         </a>
+      </p>
+      </div>
+      <div class="container">
+        <p>
+        <h3>Tag History</h3>
+        <a href="taghistory">
+          Click Here to get to your tag history
+        </a>
+        </p>
       </div>
       <!-- for debugging
                  <div class="container" th:if="${isLoggedIn} and ${isAdmin}">

--- a/src/main/resources/templates/user/taghistory.html
+++ b/src/main/resources/templates/user/taghistory.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+ <html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+  <head>
+ 	<title>Tag History</title>
+ 	<div th:replace="fragments/bootstrap_head.html"></div>
+ </head>
+
+  <body class="text-center">
+ 	<div class="container">
+ 		<div th:replace="fragments/bootstrap_nav_header.html"></div>
+ 		<h2 class="text-center">Tag History Page</h2>
+ 		<div th:replace="fragments/bootstrap_footer.html"></div>
+ 	</div>
+ 	<div th:replace="fragments/bootstrap_scripts.html"></div>
+ </body>
+
+  </html> 


### PR DESCRIPTION
link to that page is located in the settings page

Acceptance Criteria:

- [x] When going to the user settings page, there is a link to the tag history page
- [x] Link to the tag history page brings you to its placeholder page when clicked
- [x] Can access url from the home page by typing in "/user/taghistory"