### PR TITLE
tb-remove the whitespace

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/controllers/SearchController.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/controllers/SearchController.java
@@ -336,7 +336,7 @@ public class SearchController {
     // Removes whitespace from search terms //
     private String sanitizedSearchTerms(String searchTerms) 
     {
-        return searchTerms.replaceAll("\\s", "").toLowerCase();
+        return searchTerms.toLowerCase();
     }
 
     //Search the term in the table add if the term exist return true and if not return false


### PR DESCRIPTION
This pull request is meant for comparison when a query is searched, instead of standardizing everything with the removal of whitespace, the whitespace will be kept in the query(should there be any) and the only thing that is used during the comparison of a query is making it to lower cases and see if the query has been searched before. An example would be "hello world" versus "hello world" both of these might look the same but will be two different search queries in the searchTerms table