### PR TITLE
MLR - Display User's Open Pull Requests on GitHub Page

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/entities/GitHubOpenPRs.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/entities/GitHubOpenPRs.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs56.mapache_search.entities;
+
+public class GitHubOpenPRs {
+
+    public String title;
+    public String html_url;
+
+}

--- a/src/main/java/edu/ucsb/cs56/mapache_search/entities/GitHubRepos.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/entities/GitHubRepos.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs56.mapache_search.entities;
+
+public class GitHubRepos {
+
+    public String full_name;
+
+}

--- a/src/main/java/edu/ucsb/cs56/mapache_search/membership/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/membership/AuthControllerAdvice.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 
 import edu.ucsb.cs56.mapache_search.entities.AppUser;
 import edu.ucsb.cs56.mapache_search.repositories.UserRepository;
+import edu.ucsb.cs56.mapache_search.entities.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -108,7 +109,7 @@ public class AuthControllerAdvice {
     }
 
     @ModelAttribute("getTeams")
-    public List<String> getTeams(OAuth2AuthenticationToken token) {
+    public List<GitHubTeam> getTeams(OAuth2AuthenticationToken token) {
        return membershipService.getTeams(token);
     }
 
@@ -118,7 +119,7 @@ public class AuthControllerAdvice {
     }
 
     @ModelAttribute("getOpenPullRequests")
-    public List<String> getOpenPullRequests(OAuth2AuthenticationToken token) {
+    public List<GitHubOpenPRs> getOpenPullRequests(OAuth2AuthenticationToken token) {
        return membershipService.getOpenPullRequests(token);
     }
 

--- a/src/main/java/edu/ucsb/cs56/mapache_search/membership/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/membership/AuthControllerAdvice.java
@@ -117,6 +117,11 @@ public class AuthControllerAdvice {
        return membershipService.getProjectOrg();
     }
 
+    @ModelAttribute("getOpenPullRequests")
+    public List<String> getOpenPullRequests(OAuth2AuthenticationToken token) {
+       return membershipService.getOpenPullRequests(token);
+    }
+
     @ModelAttribute("role")
     public String getRole(OAuth2AuthenticationToken token) {
         return membershipService.role(token);

--- a/src/main/java/edu/ucsb/cs56/mapache_search/membership/GithubOrgMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/membership/GithubOrgMembershipService.java
@@ -192,8 +192,8 @@ public class GithubOrgMembershipService implements MembershipService {
         return githubOrg;
     }
 
-    public List<String> getTeams(final OAuth2AuthenticationToken oauthToken){
-        final List<String> teams = new ArrayList<String>();
+    public List<GitHubTeam> getTeams(final OAuth2AuthenticationToken oauthToken){
+        final List<GitHubTeam> teams = new ArrayList<GitHubTeam>();
 
         //Lots of code reuse with hasRole, could generalize
         if (oauthToken == null) {
@@ -248,7 +248,7 @@ public class GithubOrgMembershipService implements MembershipService {
             //You could build this to use the rest of the data if you wanted more than the names
             for (GitHubTeam gitHubTeam : teamArray) {
                 logger.info(user + " is part of team: " +gitHubTeam.name);
-                teams.add(gitHubTeam.name);
+                teams.add(gitHubTeam);
             }
         }
         catch(final Exception e){
@@ -261,8 +261,8 @@ public class GithubOrgMembershipService implements MembershipService {
 
     //api.github.com/repos/:owner/:repo/pulls gives all open PRs for that repo by default
     //need to loop through all repos user is in, currently hardcoded for just mapache search
-    public List<String> getOpenPullRequests(final OAuth2AuthenticationToken oauthToken){
-        final List<String> openPullRequests = new ArrayList<String>();
+    public List<GitHubOpenPRs> getOpenPullRequests(final OAuth2AuthenticationToken oauthToken){
+        final List<GitHubOpenPRs> openPullRequests = new ArrayList<GitHubOpenPRs>();
 
         if (oauthToken == null) {
             return openPullRequests;
@@ -315,9 +315,9 @@ public class GithubOrgMembershipService implements MembershipService {
                 List<GitHubOpenPRs> openPullRequestsArray = objectMapper.readValue(jr.body(), new TypeReference<List<GitHubOpenPRs>>(){});
 
                 //You could build this to use the rest of the data if you wanted more than the names
-                for (GitHubOpenPRs gitHubOpenPRs : openPullRequestsArray) {
-                    logger.info(user + " has open pull request " + gitHubOpenPRs.title);
-                    openPullRequests.add(gitHubOpenPRs.title);
+                for (GitHubOpenPRs gitHubOpenPR : openPullRequestsArray) {
+                    logger.info(user + " has open pull request " + gitHubOpenPR.title);
+                    openPullRequests.add(gitHubOpenPR);
                 }
             }
             catch(final Exception e){

--- a/src/main/java/edu/ucsb/cs56/mapache_search/membership/MembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/membership/MembershipService.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs56.mapache_search.membership;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import java.util.ArrayList;
 import java.util.List;
+import edu.ucsb.cs56.mapache_search.entities.*;
 
 public interface MembershipService {
 
@@ -26,11 +27,11 @@ public interface MembershipService {
         return isMember(oAuth2AuthenticationToken) || isAdmin(oAuth2AuthenticationToken);
     }
 
-    default public List<String> getTeams(OAuth2AuthenticationToken oAuth2AuthenticationToken){
+    default public List<GitHubTeam> getTeams(OAuth2AuthenticationToken oAuth2AuthenticationToken){
         return getTeams(oAuth2AuthenticationToken);
     }
 
-    default public List<String> getOpenPullRequests(OAuth2AuthenticationToken oAuth2AuthenticationToken){
+    default public List<GitHubOpenPRs> getOpenPullRequests(OAuth2AuthenticationToken oAuth2AuthenticationToken){
         return getOpenPullRequests(oAuth2AuthenticationToken);
     }
 

--- a/src/main/java/edu/ucsb/cs56/mapache_search/membership/MembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/membership/MembershipService.java
@@ -30,6 +30,10 @@ public interface MembershipService {
         return getTeams(oAuth2AuthenticationToken);
     }
 
+    default public List<String> getOpenPullRequests(OAuth2AuthenticationToken oAuth2AuthenticationToken){
+        return getOpenPullRequests(oAuth2AuthenticationToken);
+    }
+
     /** get list of properties 
      * @return list of repos from application.properties 
      * */

--- a/src/main/resources/templates/github/index.html
+++ b/src/main/resources/templates/github/index.html
@@ -30,6 +30,15 @@
 			</ul>
 		</tr>
 
+		<h2 class="text-center">Open pull requests</h2>
+
+		<tr th:each="openPR: ${getOpenPullRequests}"> 
+			<ul style="list-style-type:none;">
+			<li>
+			<td th:text="${openPR}"></td>
+			</li>
+			</ul>
+		</tr>
 
 		<div th:replace="fragments/bootstrap_footer.html"></div>
 	</div>

--- a/src/main/resources/templates/github/index.html
+++ b/src/main/resources/templates/github/index.html
@@ -25,7 +25,7 @@
 		<tr th:each="team: ${getTeams}"> 
 			<ul style="list-style-type:none;">
 			<li>
-			<td th:text="${team}"></td>
+			<td><a th:href="${team.html_url}" th:text="${team.name}"></a></td>
 			</li>
 			</ul>
 		</tr>
@@ -35,7 +35,7 @@
 		<tr th:each="openPR: ${getOpenPullRequests}"> 
 			<ul style="list-style-type:none;">
 			<li>
-			<td th:text="${openPR}"></td>
+			<td><a th:href="${openPR.html_url}" th:text="${openPR.title}"></a></td>
 			</li>
 			</ul>
 		</tr>


### PR DESCRIPTION
Displays all open PRs in user's repos on the github/index page. Added a helper API call to get the user's repos (formatted owner/repo) and a function to make an API call for all open PRs in each of the user's repos. Only the PRs are displayed, but should be pretty simple to display repos too if needed.