### PR TITLE
Resolved Index Out Of Bounds

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/preview/PreviewProviderServiceImpl.java
@@ -23,7 +23,7 @@ public class PreviewProviderServiceImpl implements PreviewProviderService {
 
                 // only preview questions, not other stack overflow pages
                 String[] parts = url.getPath().split("/");
-                if (parts.length > 1 && parts[1].equalsIgnoreCase("questions") && parts[2].matches("\\d+")) {
+                if (parts.length > 2 && parts[1].equalsIgnoreCase("questions") && parts[2].matches("\\d+")) {
                     return "stackexchange";
                 }
             } catch (MalformedURLException ignored) {


### PR DESCRIPTION
Upon clicking the search button in the mapache search page, it lead to an error page complaining "something went wrong, we're fixing it." Upon tracking where the error was coming from with Scott Chow, we found out that it was due to index out of bound exception in the line 26 of previewProviderServiceImp.java. You can clearly see the problem with short circuiting in line 26.

On that if-statement of that line, we first check if the parts.length > 1 and then we try to access parts[2] which is a blunder error, because if the length of "parts" is exactly 2 then we cannot access the third element. 