### PR TITLE
Reformatted the navbar so it's easier to read

### DIFF
--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -2,9 +2,6 @@
 <!-- See https://getbootstrap.com/docs/4.0/components/navbar/ for documentation on how to adjust HTML below -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <a class="navbar-brand" href="/">Mapache Search</a>
-    <a class="navbar-brand" href= "/filter" >Filter Mapache Search</a>
-    <a class="navbar-brand" href="/tags">Tags</a>
-    <a class="navbar-brand" href="/searchStatistics">Search Statistics</a>
     
 
     <!-- Button to collapse/expand navbar when it doesn't fit on the screen-->
@@ -14,6 +11,15 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
         <ul class="navbar-nav mr-auto">
+              <li class="nav-item">
+                <a class="nav-link" href= "/filter" >Filter Mapache Search</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href= "/tags" >Tags</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href= "/searchStatistics" >Search Statistics</a>
+              </li>
               <li class="nav navbar-nav" th:if="${isLoggedIn} and (${isMember} or ${isAdmin})">
                 <a class="nav-link" href="/github/">GitHub</a>
               </li>


### PR DESCRIPTION
Over time, we lost the proper formatting on the nav bar, and each link became the same size. This PR rectifies that issue, closing #282 

We should merge this after #281, which adds the search statistic page